### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .idea/
 *.iml
+.dockerignore
+Dockerfile
 bower_components/
 node_modules/
 public/
-src/scss/_custom_theme.scss
+screenshots/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node
+
+MAINTAINER Rémi Alvergnat <toilal.dev@gmail.com>
+
+RUN useradd -ms /bin/bash kong-dashboard
+
+USER kong-dashboard
+
+COPY . /home/kong-dashboard
+WORKDIR /home/kong-dashboard
+
+RUN npm install
+
+EXPOSE 8080
+
+CMD npm start
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,22 @@ npm start
 # To launch kong dashboard on a custom port
 npm start -- -p [port]
 ```
-    
+
+### Docker installation
+
+```bash
+# Build docker image from source...
+git clone https://github.com/PGBI/kong-dashboard.git
+cd kong-dashboard
+docker build -t kong-dashboard .
+
+# Launch Kong Dashboard
+docker run -d -p 8080:8080 kong-dashboard
+
+# To launch kong dashboard on a custom port
+docker run -d -p [port]:8080 kong-dashboard
+```
+
 ## Use
 
 You can now browse your kong dashboard at http://localhost:8080


### PR DESCRIPTION
I don't know if you are interested in docker, but this is a working dockerfile.

For some reason npm install doesn't work properly when using root, so i've created a kong-dashboard user inside the image.

To build: `docker build -t kong-dashboard .`

To run: `docker run -p 8080:8080 -it kong-dashboard`

If you merge this, could you then create an Automated build in docker hub ? For the image to be build on each git push ?