### PR TITLE
Rewrite of Dockerfile using alpine baseimage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM node
-
+FROM mhart/alpine-node
 MAINTAINER Rémi Alvergnat <toilal.dev@gmail.com>
 
-RUN useradd -ms /bin/bash kong-dashboard
+COPY . /data
+WORKDIR /data
 
-USER kong-dashboard
+# bower requires this configuration parameter to allow bower install using root.
+RUN echo '{ "allow_root": true }'>.bowerrc
 
-COPY . /home/kong-dashboard
-WORKDIR /home/kong-dashboard
-
-RUN npm install
+# node-sass doesn't support Alpine, so we need the build toolchain.
+RUN apk --update add ca-certificates git python build-base &&\
+    npm install && npm run install &&\
+    apk del ca-certificates git python build-base &&\
+    rm -rf /var/cache/apk/*
 
 EXPOSE 8080
 
-CMD npm start
+CMD npm run start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Kong Dashboard
 
-[**Kong**](https://getkong.org/) is a scalable, open source API Layer (also known as a API Gateway, or API Middleware). Kong runs in front of any RESTful API and provide functionalities
+[![](https://badge.imagelayers.io/pgbi/kong-dashboard:latest.svg)](https://imagelayers.io/?images=pgbi/kong-dashboard:latest 'Get your own badge on imagelayers.io')
+
+[**Kong**](https://getkong.org/) is a scalable, open source API Layer (also known as a API Gateway, or API Middleware). 
+Kong runs in front of any RESTful API and provide functionalities
 and services such as requests routing, authentication, rate limiting, etc.
 
 **Kong dashboard** is a UI tool that will let you manage your Kong Gateway setup.


### PR DESCRIPTION
This new Dockerfile use Alpine Linux as the base docker image. This is 211.9Mb, instead of 791Mb for the previous one. 

kong-dashboard user was dropped too. 

Previous image may also fail to run properly because "npm run install" command is not runned during the build.