### PR TITLE
Fix plugin list when adding a plugin to API - Kong 0.9

### DIFF
--- a/src/js/controllers/plugin.js
+++ b/src/js/controllers/plugin.js
@@ -1,5 +1,5 @@
 angular.module('app').controller("PluginController", ["$scope", "Kong", "$location", "$routeParams", "plugins", "apis", "consumers", "plugin", "Alert", function ($scope, Kong, $location, $routeParams, plugins, apis, consumers, plugin, Alert) {
-    $scope.enabled_plugins = plugins.enabled_plugins;
+    $scope.enabled_plugins = Object.keys(plugins.enabled_plugins);
     $scope.plugin = plugin ? angular.copy(plugin) : {};
 
     $scope.error = {};


### PR DESCRIPTION
Simple fix for further Kong 0.9 compatibility.

After upgrading to Kong 0.9 we weren't able to add plugins to our APIs correctly. 

Before: 
![image](https://cloud.githubusercontent.com/assets/6403172/18037463/ed24b6c2-6dd8-11e6-8f6a-6fd2daa96df9.png)

After: 
![image](https://cloud.githubusercontent.com/assets/6403172/18037465/0879171a-6dd9-11e6-94cc-827c3d17db74.png)