### PR TITLE
Support basic auth, send API requests via proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ kong-dashboard start
 
 # To start Kong Dashboard on a custom port
 kong-dashboard start -p [port]
+
+# To start Kong Dashboard with basic auth
+kong-dashboard start -a user=password
+
+# You can set basic auth user with environment variables
+# Do not set -a parameter or this will be overwritten
+set kong-dashboard-name=admin&& set kong-dashboard-pass=password&& kong-dashboard start
 ```
 
 ### From sources
@@ -94,4 +101,4 @@ vagrant up
 
 ## Use
 
-You can now browse your kong dashboard at http://localhost:8080
+You can now browse your kong dashboard at http://localhost:8080/dashboard/

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ npm install
 # Start Kong Dashboard
 npm start
 
-# To start Kong Dashboard on a custom port
-npm start -- -p [port]
+# To start Kong Dashboard on a custom port or with basic auth
+npm start -- [-p port] [-a user=password]
 ```
 
 ### With Docker

--- a/bin/kong-dashboard.js
+++ b/bin/kong-dashboard.js
@@ -17,5 +17,6 @@ if (argv._[0] === 'build') {
 
 if (argv._[0] === 'start') {
     var port = argv.p ? argv.p : 8080;
-    dashboard.serve(port);
+    var auth = argv.a;
+    dashboard.serve(port, auth);
 }

--- a/bin/kong-dashboard.js
+++ b/bin/kong-dashboard.js
@@ -4,17 +4,34 @@ var dashboard = require('../lib/kong-dashboard');
 var parseArgs = require('minimist');
 var argv = parseArgs(process.argv.slice(2));
 
-if (argv.help || argv._.length !== 1 || (argv._[0] !== 'start' && argv._[0] !== 'build')) {
-    console.log("Usage:");
-    console.log(" * kong-dashboard build");
-    console.log(" * kong-dashboard start [-p 8080]");
-    process.exit()
+// validate options
+var validOptions = ['_', 'a', 'p'];
+function hasInvalidOptions (argv) {
+    var isInvalid = false;
+    Object.keys(argv).some(function (optionName) {
+        if (validOptions.indexOf(optionName) < 0) {
+            isInvalid = true;
+            return true;
+        }
+    });
+    return isInvalid;
 }
 
+// show help
+var validCommands = ['start', 'build']
+if (argv.help || hasInvalidOptions(argv) || validCommands.indexOf(argv._[0]) < 0) {
+    console.log("Usage:");
+    console.log(" * kong-dashboard build");
+    console.log(" * kong-dashboard start [-p 8080] [-a user=password]");
+    process.exit();
+}
+
+// build assets
 if (argv._[0] === 'build') {
     dashboard.build();
 }
 
+// start server
 if (argv._[0] === 'start') {
     var port = argv.p ? argv.p : 8080;
     var auth = argv.a;

--- a/lib/kong-dashboard.js
+++ b/lib/kong-dashboard.js
@@ -30,13 +30,30 @@ exports.build = function() {
     });
 };
 
-exports.serve = function(port) {
+exports.serve = function(port, auth) {
+    // launch server
     console.log('Launching webserver');
-    var cmd = __dirname + "/../node_modules/.bin/serve --port " + port + " --no-logs --no-icons " + __dirname + "/../public";
-    var serverProcess = child_process.exec(cmd, handle_error);
-    serverProcess.stdout.on('data', function(data) {
-        process.stdout.write(data);
+    if (auth) {
+        auth = auth.split('=');
+        process.env['kong-dashboard-name'] = auth[0];
+        process.env['kong-dashboard-pass'] = auth[1];
+    }
+    var server = child_process.fork(__dirname + '/server', [], {
+        env: process.env
     });
+    server.on('message', function (message) {
+        process.stdout.write(message);
+    });
+    server.on('close', function (message) {
+        process.stdout.write('Proxy server is down.');
+    });
+    server.on('error', handle_error);
+    // launch webserver
+    // var cmd = __dirname + "/../node_modules/.bin/serve --port " + port + " --no-logs --no-icons " + __dirname + "/../public";
+    // var serverProcess = child_process.exec(cmd, handle_error);
+    // serverProcess.stdout.on('data', function(data) {
+    //     process.stdout.write(data);
+    // });
 };
 
 var compile_sass = function() {

--- a/lib/kong-dashboard.js
+++ b/lib/kong-dashboard.js
@@ -33,6 +33,9 @@ exports.build = function() {
 exports.serve = function(port, auth) {
     // launch server
     console.log('Launching webserver');
+    if (port) {
+        process.env['kong-dashboard-port'] = port;
+    }
     if (auth) {
         auth = auth.split('=');
         process.env['kong-dashboard-name'] = auth[0];
@@ -48,12 +51,6 @@ exports.serve = function(port, auth) {
         process.stdout.write('Proxy server is down.');
     });
     server.on('error', handle_error);
-    // launch webserver
-    // var cmd = __dirname + "/../node_modules/.bin/serve --port " + port + " --no-logs --no-icons " + __dirname + "/../public";
-    // var serverProcess = child_process.exec(cmd, handle_error);
-    // serverProcess.stdout.on('data', function(data) {
-    //     process.stdout.write(data);
-    // });
 };
 
 var compile_sass = function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,50 @@
+/**
+ * A proxy server with basic auth
+ */
+
+var path = require('path');
+var koa = require('koa');
+var addSlashes = require('koa-add-trailing-slashes');
+var mount = require('koa-mount');
+var serve = require('koa-static');
+var auth = require('basic-auth');
+var httpProxy = require('http-proxy');
+
+// app
+var app = koa();
+
+// add trailing slashes
+app.use(addSlashes());
+
+// serve static page
+app.use(mount('/dashboard', serve(path.join(__dirname, '../public'))));
+
+// create a proxy
+var proxy = httpProxy.createProxyServer();
+
+// proxy requests
+var name = process.env['kong-dashboard-name'];
+var pass = process.env['kong-dashboard-pass'];
+app.use(function *(next){
+  var ctx = this;
+  var credentials = auth(ctx.req)
+  if (ctx.request.method !== 'OPTION' && name) {
+    // check basic auth
+    if (!credentials || credentials.name !== name || credentials.pass !== pass) {
+      ctx.response.status = 401;
+      ctx.response.headers['WWW-Authenticate'] = 'Basic realm="example"';
+      ctx.body = 'Access denied';
+      return;
+    }
+  }
+  // proxy requests
+  yield new Promise(function (resolve, reject) {
+    proxy.web(ctx.req, ctx.res, {target: ctx.request.headers['kong-node-url']}, function (err) {
+      resolve();
+    });
+  });
+});
+
+app.listen(process.env.port || 8080);
+
+console.log('Server is runding on port ' + (process.env.port || 8080));

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,6 +37,12 @@ app.use(function *(next){
       return;
     }
   }
+  // check kong node url
+  if (!ctx.request.headers['kong-node-url']) {
+    ctx.response.status = 400;
+    ctx.body = 'Kong-Node-URL header is required';
+    return;
+  }
   // proxy requests
   yield new Promise(function (resolve, reject) {
     proxy.web(ctx.req, ctx.res, {target: ctx.request.headers['kong-node-url']}, function (err) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -45,6 +45,6 @@ app.use(function *(next){
   });
 });
 
-app.listen(process.env.port || 8080);
+app.listen(process.env['kong-dashboard-port']);
 
-console.log('Server is runding on port ' + (process.env.port || 8080));
+console.log('Server is runding on port ' + process.env['kong-dashboard-port']);

--- a/package.json
+++ b/package.json
@@ -9,13 +9,18 @@
     "url": "https://github.com/PGBI/kong-dashboard.git"
   },
   "dependencies": {
+    "basic-auth": "^1.0.4",
     "bower": "~1.6.5",
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
+    "http-proxy": "^1.15.2",
+    "koa": "^1.2.4",
+    "koa-add-trailing-slashes": "^1.1.0",
+    "koa-mount": "^1.3.0",
+    "koa-static": "^2.0.0",
     "minimist": "^1.2.0",
     "node-sass": "^3.9.0",
     "rimraf": "^2.4.4",
-    "serve": "^1.4.0",
     "uglify-js": "^2.6.1"
   },
   "bin": {

--- a/src/js/services/kong.js
+++ b/src/js/services/kong.js
@@ -2,7 +2,7 @@
  * This factory handles CRUD requests to the backend API.
  */
 angular.module('app')
-    .factory('Kong', ['$http', '$q', '$cookies', 'Alert', function ($http, $q, $cookies, Alert) {
+    .factory('Kong', ['$http', '$q', '$cookies', 'Request', 'Alert', function ($http, $q, $cookies, Request, Alert) {
         var config = {
             url : $cookies.getObject('config.url'),
             auth : { type : "no_auth" }
@@ -12,7 +12,7 @@ angular.module('app')
             config: config,
             get: function (endpoint) {
                 var deferred = $q.defer();
-                $http.get(factory.config.url + endpoint).then(function (response) {
+                Request.get(factory.config.url + endpoint).then(function (response) {
                     deferred.resolve(response.data);
                 }, function (response) {
                     factory.handleError(response, deferred, endpoint);
@@ -21,7 +21,7 @@ angular.module('app')
             },
             put: function (endpoint, data) {
                 var deferred = $q.defer();
-                $http({
+                Request({
                     method: 'PUT',
                     url: factory.config.url + endpoint,
                     data: data,
@@ -34,7 +34,7 @@ angular.module('app')
             },
             patch: function (endpoint, data) {
                 var deferred = $q.defer();
-                $http.patch(factory.config.url + endpoint, data).then(function (response) {
+                Request.patch(factory.config.url + endpoint, data).then(function (response) {
                     deferred.resolve(response.data);
                 }, function (response) {
                     factory.handleError(response, deferred, endpoint);
@@ -43,7 +43,7 @@ angular.module('app')
             },
             delete: function (endpoint) {
                 var deferred = $q.defer();
-                $http.delete(factory.config.url + endpoint).then(function (response) {
+                Request.delete(factory.config.url + endpoint).then(function (response) {
                     deferred.resolve(response);
                 }, function (response) {
                     factory.handleError(response, deferred, endpoint);
@@ -52,7 +52,7 @@ angular.module('app')
             },
             post: function (endpoint, data) {
                 var deferred = $q.defer();
-                $http.post(factory.config.url + endpoint, data).then(function (response) {
+                Request.post(factory.config.url + endpoint, data).then(function (response) {
                     deferred.resolve(response.data);
                 }, function (response) {
                     factory.handleError(response, deferred, endpoint);
@@ -83,7 +83,7 @@ angular.module('app')
                 if (!url) {
                     deferred.reject('Not reachable');
                 } else {
-                    $http({
+                    Request({
                         url: url,
                         method: 'GET',
                         timeout: 5000,

--- a/src/js/services/request.js
+++ b/src/js/services/request.js
@@ -1,0 +1,40 @@
+/**
+ * Send request via local server.
+ */
+angular.module('app')
+    .factory('Request', ['$http', '$cookies', function ($http, $cookies) {
+      var kongNodeURLHeader = 'Kong-Node-URL';
+
+      function request (options) {
+        options = addKongNodeURLHeader(options.url, options);
+        options.url = getRelativePath(options.url);
+        return $http(options);
+      };
+
+      ['get', 'delete', 'head', 'jsonp'].forEach(function (method) {
+        request[method] = function (url, options) {
+          options = addKongNodeURLHeader(url, options || {});
+          return $http[method](getRelativePath(url), options);
+        };
+      });
+
+      ['post', 'put', 'patch'].forEach(function (method) {
+        request[method] = function (url, data, options) {
+          options = addKongNodeURLHeader(url, options || {});
+          return $http[method](getRelativePath(url), data, options);
+        };
+      });
+
+      // utils
+      function addKongNodeURLHeader (url, options) {
+        options.headers = options.headers || {};
+        options.headers[kongNodeURLHeader] = url.match(/^(https?:)?\/\/[^\/]*/)[0];
+        return options;
+      }
+
+      function getRelativePath (url) {
+        return url.replace(/^(https?:)?\/\/[^\/]*/, '') || '/';
+      }
+
+      return request;
+    }]);


### PR DESCRIPTION
Replace the original server with a koa app.
All API requests will be sent to kong-dasboard server and then passed to appointed kong nodes.
New kong-dashboard server (optionally) supports basic auth itself (so that kong admin API can be set to only accessible locally).
Serve dashboard page at `/dashboard` since all requests (including `GET /`) will be forwarded to kong node.