### PR TITLE
support for enabling plugins on all APIs & working from non-root urls

### DIFF
--- a/src/js/controllers/plugin.js
+++ b/src/js/controllers/plugin.js
@@ -47,10 +47,6 @@ angular.module('app').controller("PluginController", ["$scope", "Kong", "$locati
 
     $scope.save = function () {
         beforeSave($scope.plugin.config, $scope.plugin_schema.fields);
-        if (!$scope.plugin.api_id) {
-            Alert.error("You must select an API.");
-            return;
-        }
         if (!$scope.plugin.name) {
             Alert.error("You must choose a plugin.");
             return;

--- a/src/js/controllers/plugins.js
+++ b/src/js/controllers/plugins.js
@@ -16,9 +16,11 @@ angular.module('app').controller("PluginsController", ["pluginsCollection", "$sc
     $scope.location = $location;
 
     angular.forEach($scope.plugins, function(plugin) {
-        Kong.get('/apis/' + plugin.api_id).then(function(api) {
-            plugin.api_name = api.name;
-        });
+        if(plugin.api_id) {
+           Kong.get('/apis/' + plugin.api_id).then(function(api) {
+                plugin.api_name = api.name;
+           });
+        }
         if (plugin.consumer_id) {
             Kong.get('/consumers/' + plugin.consumer_id).then(function(consumer) {
                 plugin.consumer_username = consumer.username;

--- a/src/js/services/request.js
+++ b/src/js/services/request.js
@@ -27,10 +27,9 @@ angular.module('app')
       // utils
       function setOptions(options) {
         options.headers = options.headers || {};
-        options.timeout = options.timeout || 5000;
+        options.timeout = options.timeout || 20000;
         options.headers[kongNodeURLHeader] = options.kong_url;
-        options.url = '/proxy' + options.endpoint;
-        options.timeout = 5000;
+        options.url = 'proxy' + options.endpoint;
       }
 
       return request;


### PR DESCRIPTION
this push request introduces two new features:
1. you can use the dashboard from any url prefix, e.g. localhost:8080/some-prefix/ instead of localhost:8080/. This is useful to publish the dashboard online with ProxyPass/ProxyPassReverse Apache/Nginx directives using custom urls
2. you were not able to apply a plugin to every API, since the api field was required. This limitation/constraint was related to the dashboard, not kong (which infact accept plugins without specifying an api to which apply). A typical example is the request-size-limiting plugin, that you want to apply to all all API and customers.
