### PR TITLE
Added kong node url config note

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ cd kong-dashboard
 # Start VM
 vagrant up
 ```
+## Configuration
+
+The "Kong node URL" is not "http://localhost:8001". It will be your machine/LAN IP, for example: "http://192.168.x.x:8001"
 
 ## Use
 


### PR DESCRIPTION
A common error is to add localhost:8001 as the kong node url, but it needs to be the IP address