### PR TITLE
Sort plugins alphabetically

### DIFF
--- a/src/html/plugins/form.html
+++ b/src/html/plugins/form.html
@@ -32,7 +32,7 @@
                     <select materialize-select
                             ng-model="plugin.name"
                             ng-change="loadSchema()"
-                            ng-options="p for p in enabled_plugins"
+                            ng-options="p for p in enabled_plugins | orderBy: 'toString()'"
                             ng-disabled="{{mode==='edit'}}"
                             >
                         <option value="" disabled ng-selected="{{mode==='create'}}">Choose Plugin</option>


### PR DESCRIPTION
When adding a plugin, the list wasn't sorted and made it hard to find the plugin desired. This sorts that list to make it easier. 