### PR TITLE
Set Kong node url from environment variable

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -24,12 +24,12 @@ var webapp = koa();
 // Automatically set config.url in cookie
 if (url) {
   webapp.use(function *(next){
-    var encodedServerUrl = encodeURI('"' + url + '"')
+    var encodedServerUrl = encodeURI('"' + url + '"');
     this.cookies.set('config.url', encodedServerUrl, {
       httpOnly: false
     });
     yield next;
-  })
+  });
 }
 
 // Middleware adding response headers

--- a/bin/server.js
+++ b/bin/server.js
@@ -14,11 +14,23 @@ var url_parser = require('url');
 
 var name = process.env['kong-dashboard-name'];
 var pass = process.env['kong-dashboard-pass'];
+var url = process.env['kong-dashboard-url'];
 
 /////////////////////////
 // Serving angular app //
 /////////////////////////
 var webapp = koa();
+
+// Automatically set config.url in cookie
+if (url) {
+  webapp.use(function *(next){
+    var encodedServerUrl = encodeURI('"' + url + '"')
+    this.cookies.set('config.url', encodedServerUrl, {
+      httpOnly: false
+    });
+    yield next;
+  })
+}
 
 // Middleware adding response headers
 webapp.use(function *(next){


### PR DESCRIPTION
This adds a middleware in Koa server when `kong-dashboard-url` is set. The middleware will set `config.url` cookie so that the client can skip the configuration in UI.

A docker image based on this PR is available at `siwatp/kong-dashboard` 👍 