### PR TITLE
Serverless option

### DIFF
--- a/src/html/config.html
+++ b/src/html/config.html
@@ -43,6 +43,15 @@
 
             <div class="row">
                 <div class="input-field col s12">
+                    <input ng-model="config.useproxy" name="useproxy_option" type="checkbox" id="useproxy_option" />
+                    <label for="useproxy_option">
+                        Use dashboard proxy. Turn off if you can connect to Kong directly.
+                    </label>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="input-field col s12">
                     <button type="submit" class="waves-effect waves-green btn right">Save</button>
                 </div>
             </div>

--- a/src/js/controllers/config.js
+++ b/src/js/controllers/config.js
@@ -2,13 +2,22 @@ angular.module('app').controller("ConfigController", ["$scope", "Kong", "Alert",
     $scope.config = angular.copy(Kong.config);
 
     var first_setup = !$scope.config.url;
+    if (first_setup){
+        $scope.config.useproxy=true;
+    }
 
     $scope.update = function() {
         if (!$scope.config.url) {
             $scope.config.url = "http://localhost:8001";
         }
-        if ($scope.config.url.toLowerCase().indexOf("http") == -1) {
+        if ($scope.config.useproxy && $scope.config.url.toLowerCase().indexOf("http") == -1) {
             $scope.config.url = "http://" + $scope.config.url;
+        }
+        if (!$scope.config.useproxy){
+            var len = $scope.config.url.length;
+            if ($scope.config.url.charAt(len - 1) == '/') {
+                $scope.config.url = $scope.config.url.substr(0, len - 1);
+            }
         }
 
         Kong.setConfig($scope.config).then(function() {

--- a/src/js/services/kong.js
+++ b/src/js/services/kong.js
@@ -2,12 +2,13 @@
  * This factory handles CRUD requests to the backend API.
  */
 angular.module('app')
-  .factory('Kong', ['$http', '$q', '$cookies', 'Request', 'Alert', function ($http, $q, $cookies, Request, Alert) {
-    var config = {
-      url : $cookies.getObject('config.url'),
-      auth : { type : "no_auth" },
-      gelato : $cookies.getObject('config.gelato')
-    };
+    .factory('Kong', ['$http', '$q', '$cookies', 'Request', 'Alert', function ($http, $q, $cookies, Request, Alert) {
+        var config = {
+            url : $cookies.getObject('config.url'),
+            auth : { type : "no_auth" },
+            gelato : $cookies.getObject('config.gelato'),
+            useproxy: $cookies.getObject('config.useproxy')
+        };
 
     var factory = {
       config: config,
@@ -43,6 +44,7 @@ angular.module('app')
           Request({
             kong_url: url,
             endpoint: '/',
+            useproxy: config.useproxy,
             method: 'GET'
           }).then(function (response) {
             if (
@@ -69,12 +71,14 @@ angular.module('app')
         }
         return deferred.promise;
       },
-
       setConfig: function (config) {
         var deferred = $q.defer();
         factory.checkConfig(config).then(function () {
           factory.config = config;
           $cookies.putObject('config.url', factory.config.url, {
+            expires: new Date(new Date().getTime() + 1000 * 24 * 3600 * 60) // remember 60 days
+          });
+          $cookies.putObject('config.useproxy', factory.config.useproxy, {
             expires: new Date(new Date().getTime() + 1000 * 24 * 3600 * 60) // remember 60 days
           });
           deferred.resolve();
@@ -95,6 +99,7 @@ angular.module('app')
           Request({
             kong_url: factory.config.url,
             endpoint: endpoint,
+            useproxy: factory.config.useproxy,
             method: method
           }).then(function (response) {
             deferred.resolve(response.data);
@@ -115,6 +120,7 @@ angular.module('app')
           Request({
             kong_url: factory.config.url,
             endpoint: endpoint,
+            useproxy: factory.config.useproxy,
             method: method,
             data: data,
           }).then(function (response) {

--- a/src/js/services/request.js
+++ b/src/js/services/request.js
@@ -28,9 +28,13 @@ angular.module('app').factory('Request', ['$http', function ($http) {
     options.headers = options.headers || {};
     options.timeout = options.timeout || 5000;
     options.headers[kongNodeURLHeader] = options.kong_url;
-    options.url = './proxy' + options.endpoint;
+    if (options.useproxy==true)
+      options.url = './proxy' + options.endpoint;
+    else{
+      options.url = options.kong_url + options.endpoint;
+    }
     options.timeout = 30000;
   }
-
+  
   return request;
 }]);


### PR DESCRIPTION
Option, which can be turned on in the configuration page, to connect directly to Kong instead of using server proxy (same way it worked on version 1). Some teams, like ours, prefer it this way.