### PR TITLE
Converted environment vars to be usable in Linux and Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ kong-dashboard start -a user=password
 
 # You can set basic auth user with environment variables
 # Do not set -a parameter or this will be overwritten
-set KONG_DASHBOARD_NAME=admin && set KONG_DASHBOARD_PASS=password && kong-dashboard start
+export KONG_DASHBOARD_NAME=admin && export KONG_DASHBOARD_PASS=password && kong-dashboard start
 ```
 
 ### From sources

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ kong-dashboard start -a user=password
 
 # You can set basic auth user with environment variables
 # Do not set -a parameter or this will be overwritten
-set kong-dashboard-name=admin && set kong-dashboard-pass=password && kong-dashboard start
+set KONG_DASHBOARD_NAME=admin && set KONG_DASHBOARD_PASS=password && kong-dashboard start
 ```
 
 ### From sources

--- a/bin/kong-dashboard.js
+++ b/bin/kong-dashboard.js
@@ -39,12 +39,12 @@ if (argv._[0] === 'start') {
     // launch server
     console.log('Launching webserver');
     if (port) {
-        process.env['kong-dashboard-port'] = port;
+        process.env['KONG_DASHBOARD_PORT'] = port;
     }
     if (auth) {
         auth = auth.split('=');
-        process.env['kong-dashboard-name'] = auth[0];
-        process.env['kong-dashboard-pass'] = auth[1];
+        process.env['KONG_DASHBOARD_NAME'] = auth[0];
+        process.env['KONG_DASHBOARD_PASS'] = auth[1];
     }
     var server = child_process.fork(__dirname + '/server', [], {
         env: process.env

--- a/bin/server.js
+++ b/bin/server.js
@@ -12,8 +12,8 @@ var auth = require('basic-auth');
 var httpProxy = require('http-proxy');
 var url_parser = require('url');
 
-var name = process.env['kong-dashboard-name'];
-var pass = process.env['kong-dashboard-pass'];
+var name = process.env['KONG_DASHBOARD_NAME'];
+var pass = process.env['KONG_DASHBOARD_PASS'];
 
 /////////////////////////
 // Serving angular app //
@@ -143,6 +143,6 @@ app.use(mount('/', webapp));
 // serve proxy server
 app.use(mount('/proxy', proxyapp));
 
-app.listen(process.env['kong-dashboard-port']);
+app.listen(process.env['KONG_DASHBOARD_PORT']);
 
-console.log('Server is running on port ' + process.env['kong-dashboard-port']);
+console.log('Server is running on port ' + process.env['KONG_DASHBOARD_PORT']);


### PR DESCRIPTION
Linux and Kubernetes do not allow the use of - characters in environment variables.