### PR TITLE
Add anonymous health check endpoint when using basic auth

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -107,6 +107,10 @@ function debugResponse(response) {
 
 function addBasicAuthMiddleware(app, credentials) {
   app.use((ctx, next) => {
+    if (ctx.request.url == '/healthz') {
+      ctx.body = '';
+      return;
+    }
     if (ctx.request.method == 'OPTIONS') {
       return next();
     }


### PR DESCRIPTION
We are running kong-dashboard in a Kubernetes cluster, and it is published through an Ingress controller. The Kubernetes Ingress controller requires all backend services to have a public HTTP endpoint that returns status 200 for health checking.

When using basic auth for kong-dashboard, all routes require authentication, or else they return status code 401. This addition provides a route that returns status code 200 with an empty body when basic auth is enabled.

The endpoint is called "healthz" because that is the default name used throughout the Kubernetes documentation.