### PR TITLE
Add default empty basic auth password

### DIFF
--- a/src/html/consumers/form.html
+++ b/src/html/consumers/form.html
@@ -131,7 +131,7 @@
             </div>
             <div class="input-field col s6 offset-s3">
               <input id="password" ng-model="new_basic_auth.password" type="password" class="validate"
-                     ng-class="{invalid: error.new_basic_auth.password}">
+                     ng-class="{invalid: error.new_basic_auth.password}" ng-init="new_basic_auth.password=''">
               <label for="password">Password</label>
               <app-field-error error="error.new_basic_auth.password"></app-field-error>
             </div>


### PR DESCRIPTION
Currently, if we don't explicitly click password and set the password to empty, the payload will not have the `password` field, which will result in different encrypted `username:password` hash in kong. 


## currently (without any edit to password field)

![image](https://user-images.githubusercontent.com/658840/36513730-e219f704-1725-11e8-8a17-258621381496.png)

## currently (click password input, type something, and hit backspace and clear the password)

![image](https://user-images.githubusercontent.com/658840/36513710-c601db9a-1725-11e8-8d91-d753f491103d.png)

## this pr (consistent behavior)

![image](https://user-images.githubusercontent.com/658840/36513710-c601db9a-1725-11e8-8d91-d753f491103d.png)


