### PR TITLE
Fix resource url if parent is set

### DIFF
--- a/src/pages/index_resources/index_resources.controller.js
+++ b/src/pages/index_resources/index_resources.controller.js
@@ -16,7 +16,7 @@
 
     var fetchEndpoint = '/' + resourceType.toLowerCase() + 's?';
     if (parent) {
-      fetchEndpoint = '/' + parentType.toLowerCase() + 's/' + parent.id + fetchEndpoint + '?';
+      fetchEndpoint = '/' + parentType.toLowerCase() + 's/' + parent.id + fetchEndpoint;
     }
 
     switch(resourceType) {


### PR DESCRIPTION
No need to send `??`, for example

```
http://localhost:8080/proxy/apis/<uuid>/plugins??
```

breaks the fetch call.