### PR TITLE
Added  to 0.14 scheme

### DIFF
--- a/lib/kong-schemas.js
+++ b/lib/kong-schemas.js
@@ -1809,7 +1809,7 @@ var schemas = {
           type: 'array',
           items: {
             type: 'string',
-            enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+            enum: ['HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
           },
           description: "A list of HTTP methods that match this Route. At least one of hosts, paths, or methods must be set."
         },

--- a/lib/kong-schemas.js
+++ b/lib/kong-schemas.js
@@ -1829,6 +1829,12 @@ var schemas = {
           },
           description: "A list of paths that match this Route. At least one of hosts, paths, or methods must be set."
         },
+        regex_priority: {
+          required: false,
+          type: 'number',
+          default: '0',
+          description: "Determines the relative order of this Route against others when evaluating regex paths. Routes with higher numbers will have their regex paths evaluated first. Defaults to 0."
+        },
         strip_path: {
           required: false,
           type: 'boolean',


### PR DESCRIPTION
The priority of a route was already visible on the route index but it wasn't editable.
This pull request adds the `regex_priority` field to the 0.14 scheme thereby adding it to the route's edit view.