### PR TITLE
Fix slash in offset causing next page not loading properly

### DIFF
--- a/src/pages/index_resources/index_resources.controller.js
+++ b/src/pages/index_resources/index_resources.controller.js
@@ -153,7 +153,7 @@
           vm.resources = [];
         }
         vm.resources.push.apply(vm.resources, response.data);
-        nextPage = response.offset ? fetchEndpoint + '&offset=' + response.offset : null;
+        nextPage = response.offset ? fetchEndpoint + '&offset=' + encodeURIComponent(response.offset) : null;
         nextPageLoading = false;
 
         // appending related resources, if any.


### PR DESCRIPTION
We got offset as "EKwsAROP9kPxqPpvz7kWC+sA8H///5sA" in our dev environment apis list (first page's next URL), which seems cause dashboard always loading first page while reach the end of webpage.
I've added URLencode for this parameter to help loading next page properly.