### PR TITLE
Fix #190

### DIFF
--- a/bin/kong-dashboard.js
+++ b/bin/kong-dashboard.js
@@ -158,6 +158,11 @@ function start(argv) {
     terminal.error(error);
     process.exit(1);
   }).then((version) => {
+    var rcRegex = /rc[\d]{0,}$/;
+    if (rcRegex.test(version)) {
+      terminal.warning("Kong version is a release candidate e.g " + version + ". You may encounter issues");
+      version = version.replace(rcRegex, '');
+    }
     if (semver.lt(version, '0.9.0')) {
       terminal.error("This version of Kong dashboard doesn't support Kong v0.9 and lower.");
       process.exit(1);


### PR DESCRIPTION
Catch rc version, put a warning about rc version
but continue by fixing the version to avoid failure when running `semver.lt` comparison

Kong: 1.1.0rc2 (current deb for community edition when using bintray e.g https://bintray.com/kong/kong-community-edition-deb by following https://docs.konghq.com/install/ubuntu/ section "Apt Repositories")
Node: v10.15.0
NPM: 6.9.0
Kong Dashboard: 3.6.0