### PR TITLE
fix create_or_update_resource controller and oauth2 admin api schema for 1.0

### DIFF
--- a/lib/kong-schemas.js
+++ b/lib/kong-schemas.js
@@ -2230,9 +2230,12 @@ var schemas = {
           type: 'string',
           description: "You can optionally set your own unique client_secret. If missing, the plugin will generate one.",
         },
-        redirect_uri: {
-          type: 'string',
-          description: "The URL in your app where users will be sent after authorization (RFC 6742 Section 3.1.2).",
+        redirect_uris: {
+          type: 'array',
+          items: {
+            type: "string"
+          },
+          description: "An array with one or more URLs in your app where users will be sent after authorization (RFC 6742 Section 3.1.2).",
         }
       }
     },
@@ -2675,9 +2678,12 @@ var schemas = {
           type: 'string',
           description: "You can optionally set your own unique client_secret. If missing, the plugin will generate one.",
         },
-        redirect_uri: {
-          type: 'string',
-          description: "The URL in your app where users will be sent after authorization (RFC 6742 Section 3.1.2).",
+        redirect_uris: {
+          type: 'array',
+          items: {
+            type: "string"
+          },
+          description: "An array with one or more URLs in your app where users will be sent after authorization (RFC 6742 Section 3.1.2).",
         }
       }
     },

--- a/src/pages/create_or_update_resource/create_or_update_resource.controller.js
+++ b/src/pages/create_or_update_resource/create_or_update_resource.controller.js
@@ -20,7 +20,6 @@
     switch(resourceType) {
       case 'acl':
         vm.title = 'Add Consumer "' + (parent.username || parent.custom_id) + '" to a Group.';
-        vm.resource.consumer_id = parent.id;
         break;
       case 'API':
         vm.title = resource ? 'Update API' : 'Create API';
@@ -28,7 +27,6 @@
       case 'basic-auth-credential':
         vm.title = resource ? 'Update credential' : 'Create basic auth credential for Consumer "' + (parent.username || parent.custom_id) + '"';
         delete vm.schema.properties.consumer_id;
-        vm.resource.consumer_id = parent.id;
         break;
       case 'certificate':
         vm.title = resource ? 'Update Certificate' : 'Create Certificate';
@@ -38,21 +36,17 @@
         break;
       case 'hmac-credential':
         vm.title = resource ? 'Update credential' : 'Create HMAC credential for Consumer "' + (parent.username || parent.custom_id) + '"';
-        vm.resource.consumer_id = parent.id;
         break;
       case 'jwt-credential':
         vm.title = 'Create a JWT for Consumer "' + (parent.username || parent.custom_id) + '"';
-        vm.resource.consumer_id = parent.id;
         break;
       case 'auth-key':
         vm.title = resource ? 'Update Key' : 'Create a Key for Consumer "' + (parent.username || parent.custom_id) + '"';
         delete vm.schema.properties.consumer_id;
-        vm.resource.consumer_id = parent.id;
         break;
       case 'oauth2-credential':
         vm.title = resource ? 'Update Oauth2 credential' : 'Create an oauth2 credential for Consumer "' + (parent.username || parent.custom_id) + '"';
         delete vm.schema.properties.consumer_id;
-        vm.resource.consumer_id = parent.id;
         break;
       case 'plugin':
         vm.title = resource ? 'Update Plugin' : 'Create Plugin';


### PR DESCRIPTION
This PR introduces the following changes:

- The `redirect_uri` field of OAuth 2.0 plugin has been changed to `redirect_uris` in version 0.15 and 1.0.x
- remove consumer_id from request body when creating acl/basic-auth/hmac-auth/jwt/key-auth/oauth2 resources
