### PR TITLE
fix: Created Column now shows the correct time

### DIFF
--- a/src/pages/index_resources/index_resources.controller.js
+++ b/src/pages/index_resources/index_resources.controller.js
@@ -5,9 +5,9 @@
     .module('app')
     .controller('IndexResources', IndexResources);
 
-  IndexResources.$inject = ["resourceType", "resourceName", "Kong", "Alert", "parentType", "parent"];
+  IndexResources.$inject = ["resourceType", "resourceName", "Kong", "env", "Alert", "parentType", "parent"];
 
-  function IndexResources(resourceType, resourceName, Kong, Alert, parentType, parent) {
+  function IndexResources(resourceType, resourceName, Kong, env, Alert, parentType, parent) {
     var vm = this;
 
     vm.resources = null;
@@ -156,8 +156,13 @@
         nextPage = response.offset ? fetchEndpoint + '&offset=' + encodeURIComponent(response.offset) : null;
         nextPageLoading = false;
 
+        var isTimeInSeconds = isKong1xVersion(env.kong_version);
+
         // appending related resources, if any.
         vm.resources.forEach(function(resource) {
+          if (resource.created_at && isTimeInSeconds) {
+            resource.created_at *= 1000;
+          }
           if (!resource.api && resource.api_id) {
             Kong.get('/apis/' + resource.api_id).then(function(api) {
               resource.api = api;
@@ -226,5 +231,9 @@
         });
       });
     };
+
+    function isKong1xVersion(versionStr) {
+      return versionStr >= "1.0.0" || versionStr.substring(0, 4) === "0.15"
+    }
   }
 })();

--- a/src/pages/index_resources/index_resources.controller.js
+++ b/src/pages/index_resources/index_resources.controller.js
@@ -156,11 +156,11 @@
         nextPage = response.offset ? fetchEndpoint + '&offset=' + encodeURIComponent(response.offset) : null;
         nextPageLoading = false;
 
-        var isTimeInSeconds = isKong1xVersion(env.kong_version);
+        var isTimestampInSeconds = env.kong_version >= "0.14";
 
         // appending related resources, if any.
         vm.resources.forEach(function(resource) {
-          if (resource.created_at && isTimeInSeconds) {
+          if (isTimestampInSeconds && resource.created_at) {
             resource.created_at *= 1000;
           }
           if (!resource.api && resource.api_id) {
@@ -231,9 +231,5 @@
         });
       });
     };
-
-    function isKong1xVersion(versionStr) {
-      return versionStr >= "1.0.0" || versionStr.substring(0, 4) === "0.15"
-    }
   }
 })();


### PR DESCRIPTION
Fix #196 

`created_at` has been changed to second-level numbers since version 0.14.