### PR TITLE
no check kong version for left aside menu

### DIFF
--- a/bin/kong-dashboard.js
+++ b/bin/kong-dashboard.js
@@ -159,12 +159,12 @@ function start(argv) {
     process.exit(1);
   }).then((version) => {
     if (semver.lt(version, '0.9.0')) {
-      terminal.error("This version of Kong dashboard doesn't support Kong v0.9 and lower.");
-      process.exit(1);
+      terminal.error("This version of Kong dashboard doesn't support Kong v0.9 and lower.current is -->"+version);
+      // process.exit(1);
     }
     if (semver.gte(version, '2.0.0')) {
-      terminal.error("This version of Kong dashboard doesn't support Kong v2.0 and higher.");
-      process.exit(1);
+      terminal.error("This version of Kong dashboard doesn't support Kong v2.0 and higher.current is -->"+version);
+      // process.exit(1);
     }
     terminal.success("Connected to Kong on " + argv.kongUrl + ".");
     terminal.info("Kong version is " + version);

--- a/lib/kong-schemas.js
+++ b/lib/kong-schemas.js
@@ -2989,7 +2989,13 @@ var schemas = {
 
 var Schema = {
   get: function(version) {
-    return schemas[semver.major(version) + '.' + semver.minor(version)];
+    let schema = schemas[semver.major(version) + '.' + semver.minor(version)];
+    if(!schema){
+      for(let key in schemas){
+        schema=schemas[key]
+      }
+    }
+    return schema;
   }
 };
 


### PR DESCRIPTION
when use kong 1.2 or 1.3 version ,the kong-dashboard left aside menu can't show route ,service and so on.
if no match with kong version ,it can use the latest config schema.